### PR TITLE
Meslek Otomatik Doldurma Fix

### DIFF
--- a/fx_ev/lua/autorun/client/cl_evsistemi.lua
+++ b/fx_ev/lua/autorun/client/cl_evsistemi.lua
@@ -134,12 +134,12 @@ local function _menu()
 			end
 
 			if target==nil then
-				chat.AddText(Color(255,128,128),'[EV SISTEMI] ',color_white,'Hedef bulunamadi!')
+				chat.AddText(Color(255,128,128),'[FexaEv] ',color_white,'Hedef bulunamadi!')
 				return
 			end	
 
 			if not table.HasValue(homes, checks.home) then
-				chat.AddText(Color(255,128,128),'[EV SISTEMI] ',color_white,'Girdiginiz ev bulunamadi!')
+				chat.AddText(Color(255,128,128),'[FexaEv] ',color_white,'Girdiginiz ev bulunamadi!')
 				return
 			end			
 

--- a/fx_ev/lua/autorun/server/ev_sql.lua
+++ b/fx_ev/lua/autorun/server/ev_sql.lua
@@ -1,3 +1,5 @@
+include("ev_config.lua")
+
 hook.Add("Initialize","ev_hook_initialize",function()
 	sql.Query("CREATE TABLE IF NOT EXISTS ev_sistemi(ev string NOT NULL, id BIGINT NOT NULL)")
 	ev_print("SQL table kuruldu!")
@@ -12,13 +14,21 @@ local order = {
 }
 
 hook.Add("PlayerInitialSpawn","ev_hook_initialspawn",function(ply)
+	
 	local query = sql.QueryValue("SELECT ev FROM ev_sistemi WHERE id="..ply:SteamID64().."")
 	local setTeam = ply.changeTeam or ply.SetTeam
-	if query!=nil and isstring(query) then
+
+	if query != nil and isstring(query) then
 		ply:SetNWString("hogwarts_ev",query)
 		ply:SetNWString("Evcek",tostring(order[query]))
-		timer.Simple(0,function() setTeam(ply, ev_sistemi[query or "evsiz"], true) end)
-	else
-		timer.Simple(0,function() setTeam(ply, ev_sistemi["evsiz"], true) end)
+		
+		if FX_EV.AutoJob then 	
+			timer.Simple(0, function() 
+				setTeam(ply, FX_EV.Jobs[query or "evsiz"], true) 
+			end) 
+		end
+	elseif FX_EV.AutoJob then
+		timer.Simple(0,function() setTeam(ply, FX_EV.Jobs["evsiz"], true) end)
 	end
+
 end)

--- a/fx_ev/lua/autorun/sh_ev_sistemi.lua
+++ b/fx_ev/lua/autorun/sh_ev_sistemi.lua
@@ -1,3 +1,3 @@
 function ev_print(msg)
-	MsgC(Color(255,0,255),"[EV SİSTEMİ] ",color_white,msg.."\n")
+	MsgC(Color(255,0,255),"[FexaEv] ",color_white,msg.."\n")
 end

--- a/fx_ev/lua/ev_config.lua
+++ b/fx_ev/lua/ev_config.lua
@@ -1,0 +1,21 @@
+--[[
+
+	Fexa Ev Sistemi
+		Config
+
+	(remake by Pikod)
+
+]]--
+
+FX_EV = {} -- Dokunmayınız
+
+-- Oyuna girince otomatik meslek verilsin mi ?
+FX_EV.AutoJob = true
+
+-- Oyuna girince otomatik olarak meslek vermesi için mesleklerin isimlerini sunucunuzda ki gibi yapın.
+FX_EV.Jobs = {
+	["gryffindor"] = "Gryffindor Öğrencisi",
+	["hufflepuff"] = "Hufflepuff Öğrencisi",
+	["ravenclaw"] = "Ravenclaw Öğrencisi",
+	["slytherin"] = "Slytherin Öğrencisi"
+}


### PR DESCRIPTION
**Otomatik meslek doldurma sistemi fix;**
Oyuncu oyuna girdiğinde otomatik takım değişimi için yazılan kodda ev_sistemi değişkeni bulunmuyor.
Hata verdiği için bir config dosyası oluşturdum ve içerisine atılması gereken mesleklerin bilgisini alan bir değer oluşturdum:

```lua
FX_EV.Jobs = {
	["gryffindor"] = "Gryffindor Öğrencisi",
	["hufflepuff"] = "Hufflepuff Öğrencisi",
	["ravenclaw"] = "Ravenclaw Öğrencisi",
	["slytherin"] = "Slytherin Öğrencisi"
}
```
Değişiklikler:
* ev_config.lua
* Daha iyi gözüktüğünü düşündüğüm için EV SİSTEMİ yerine FexaEv yazdım.