### PR TITLE
Fexa - Parşomen Sistemi Bug Fix (Parşömen aktarımında MySQL kullanan DarkRP sunucuları hata veriyor)

### DIFF
--- a/fx_kutuphane/lua/autorun/server/sv_kutuphane.lua
+++ b/fx_kutuphane/lua/autorun/server/sv_kutuphane.lua
@@ -159,23 +159,29 @@ net.Receive("kutuphane_menu", function(_, ply)
 		local bid = net.ReadString();
 		local count = net.ReadUInt(8);
 
-		local buid = sql.QueryValue("SELECT uid FROM playerinformation WHERE steamID='"..bid.."'");
+		MySQLite.query("SELECT CAST(uid as CHAR) FROM playerinformation WHERE steamID='"..bid.."'", function(data)
+			local buid = data[1]["CAST(uid as CHAR)"]
+			if not buid then
+				ply:FX_Notify(fx_kutuphane.dil["notfound"]);
+				return
+			end
 
-		if not buid then
-			ply:FX_Notify(fx_kutuphane.dil["notfound"]);
-			return
-		end
+			MySQLite.query("SELECT rpname FROM darkrp_player WHERE uid="..buid, function(data1)
+				local bname = data1[1]["rpname"]
+				if not bname then
+					ply:FX_Notify(fx_kutuphane.dil["notfound"]);
+					return
+				end
 
-		local bname = sql.QueryValue("SELECT rpname FROM darkrp_player WHERE uid="..buid);
+				net.Start("kutuphane_menu_transfer")
+					net.WriteString(bname)
+				net.Send(ply)
+			end);
 
-		if not bname then
-			a:FX_Notify(fx_kutuphane.dil["notfound"]);
-			return
-		end
-
-		net.Start("kutuphane_menu_transfer")
-			net.WriteString(bname)
-		net.Send(ply)
+			
+		end)
+		
+		
 		return;
 	elseif (order=="transfer") then
 		local bid = net.ReadString();


### PR DESCRIPTION
Parşömen sistemi "DarkRPModification/lua/darkrp_config/mysql.lua" dosyasından **MySQL is enabled** seçeneği açıldığı taktirde çalışmıyor.

Bunun sebebi öğrenciler aktif değilken bile parşömen aktarımını mümkün kılan DarkRP tarafından base alınmış 'playerinformation' tablosunun **fx_kutuphane** eklentisinde kullanımıdır.
Playerinformation tablosu tam olarak bu amaçla üretilse de eklentide kullanımı hatalıdır. Sürekli local sqlde olmayacağı için sql metodunu kullanarak data'ı sorgulamaya çalışmak MySQL'i aktif olan sunucularda hata yaratacaktır (bende olduğu gibi).
Sorunu çözmek amacıyla MySQL'in tmysql, mysqloo ve sql protokollerinin üçünü birleştirip tercih edilenden bilgileri döndüren sınıfını kullandım.

Zaten DarkRP oyun modu ile ilgili bir veri, fonksiyon veya arguman kullanılacağı zaman DarkRP'nin ürettiği metodlardan yararlanmak en sağlıklısıdır.